### PR TITLE
fix: patch version loop

### DIFF
--- a/blueprints/foundational/package.json
+++ b/blueprints/foundational/package.json
@@ -17,7 +17,7 @@
     "@aws-sdk/client-organizations": "^3.774.0",
     "@aws-sdk/client-securityhub": "^3.775.0",
     "@aws-sdk/util-retry": "^3.370.0",
-    "@superluminar-io/aws-luminarlz-cli": "^0.0.25",
+    "@superluminar-io/aws-luminarlz-cli": "^0.0",
     "aws-cdk-lib": "2.198.0",
     "aws-lambda": "^1.0.7",
     "constructs": "^10.0.0",


### PR DESCRIPTION
Before Dependabot would auto-update the patch version which created a new patch version again.