### PR TITLE
fix: moves CloudTrail resolution to init and hardens finalize fallback checks.

### DIFF
--- a/blueprints/foundational/README.md
+++ b/blueprints/foundational/README.md
@@ -11,7 +11,7 @@ to manage and deploy the LZA config.
 * [templates](templates) contains the liquid templates and other files that are used to generate the LZA config.
 * [customizations](customizations) contains a CDK app used to generate the CloudFormation templates that are defined in the [customizations-config](templates/customizations-config.yaml.liquid).
 * [config.ts](config.ts) defines how the templates are generated and all project relevant configurations.
-  * `cloudTrailLogGroupName` defaults to `__AUTO__`, which resolves the Control Tower CloudTrail log group during `deploy`.
+  * `cloudTrailLogGroupName` is resolved during `init` when initial rollout prerequisites are ready.
 * [docs](docs) contains:
   * [Architecture Decision Records (ADRs)](docs/adrs) that document project-specific decisions.
   * [Runbooks](docs/runbooks) that help you with Landing Zone tasks.

--- a/blueprints/foundational/README.md
+++ b/blueprints/foundational/README.md
@@ -11,7 +11,6 @@ to manage and deploy the LZA config.
 * [templates](templates) contains the liquid templates and other files that are used to generate the LZA config.
 * [customizations](customizations) contains a CDK app used to generate the CloudFormation templates that are defined in the [customizations-config](templates/customizations-config.yaml.liquid).
 * [config.ts](config.ts) defines how the templates are generated and all project relevant configurations.
-  * `cloudTrailLogGroupName` is resolved during `init` when initial rollout prerequisites are ready.
 * [docs](docs) contains:
   * [Architecture Decision Records (ADRs)](docs/adrs) that document project-specific decisions.
   * [Runbooks](docs/runbooks) that help you with Landing Zone tasks.

--- a/blueprints/foundational/config.ts
+++ b/blueprints/foundational/config.ts
@@ -46,9 +46,9 @@ export const ENABLED_REGIONS = [GLOBAL_REGION, HOME_REGION];
 
 /**
  * The CloudTrail log group that Control Tower creates in the home region.
- * Use '__AUTO__' to resolve it during deployment.
+ * This value is resolved during `init` when initial rollout prerequisites are available.
  */
-export const CLOUDTRAIL_LOG_GROUP_NAME = '__AUTO__';
+export const CLOUDTRAIL_LOG_GROUP_NAME = '<<AWS_CLOUDTRAIL_LOG_GROUP_NAME>>';
 
 /**
  * The groups should be aligned with the groups in the AWS IAM Identity Center.

--- a/blueprints/foundational/config.ts
+++ b/blueprints/foundational/config.ts
@@ -46,7 +46,6 @@ export const ENABLED_REGIONS = [GLOBAL_REGION, HOME_REGION];
 
 /**
  * The CloudTrail log group that Control Tower creates in the home region.
- * This value is resolved during `init` when initial rollout prerequisites are available.
  */
 export const CLOUDTRAIL_LOG_GROUP_NAME = '<<AWS_CLOUDTRAIL_LOG_GROUP_NAME>>';
 

--- a/blueprints/foundational/config.ts
+++ b/blueprints/foundational/config.ts
@@ -305,6 +305,6 @@ export const config: Config = {
   managementAccountId: MANAGEMENT_ACCOUNT_ID,
   homeRegion: HOME_REGION,
   enabledRegions: ENABLED_REGIONS,
-  cloudTrailLogGroupName: CLOUDTRAIL_LOG_GROUP_NAME,
   awsAcceleratorVersion: AWS_ACCELERATOR_VERSION,
+  cloudTrailLogGroupName: CLOUDTRAIL_LOG_GROUP_NAME,
 };

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,5 +1,4 @@
 import { Command } from 'clipanion';
-import { applyAutoCloudTrailLogGroupName } from '../core/accelerator/config/cloudtrail';
 import { publishConfigOut } from '../core/accelerator/config/publish';
 import { synthConfigOut } from '../core/accelerator/config/synth';
 import { customizationsPublishCdkAssets } from '../core/customizations/assets';
@@ -15,7 +14,6 @@ export class Deploy extends Command {
   async execute() {
     await customizationsCdkSynth();
     await synthConfigOut();
-    await applyAutoCloudTrailLogGroupName();
     await customizationsPublishCdkAssets();
     await publishConfigOut();
     console.log('Done. ✅');

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,7 +52,6 @@ export interface BaseConfig {
   awsAcceleratorInstallerRepositoryBranchNamePrefix: string;
   awsAcceleratorInstallerStackTemplateUrlPattern: string;
   maxParallelCdkAssetManifestUploads: number;
-  cloudTrailLogGroupName: string;
 }
 
 export interface Config extends BaseConfig {
@@ -62,6 +61,7 @@ export interface Config extends BaseConfig {
   managementAccountId: string;
   homeRegion: string;
   enabledRegions: string[];
+  cloudTrailLogGroupName: string;
 }
 
 export const baseConfig: BaseConfig = {
@@ -78,7 +78,6 @@ export const baseConfig: BaseConfig = {
   awsAcceleratorInstallerRepositoryBranchNamePrefix: AWS_ACCELERATOR_INSTALLER_REPOSITORY_BRANCH_NAME_PREFIX,
   awsAcceleratorInstallerStackTemplateUrlPattern: AWS_ACCELERATOR_INSTALLER_STACK_TEMPLATE_URL_PATTERN,
   maxParallelCdkAssetManifestUploads: 200,
-  cloudTrailLogGroupName: '__AUTO__',
 };
 
 let loadedConfig: Config | undefined;

--- a/src/core/accelerator/config/cloudtrail.ts
+++ b/src/core/accelerator/config/cloudtrail.ts
@@ -75,6 +75,8 @@ const resolveCloudTrailLogGroupName = async (region: string): Promise<string> =>
   return selectControlTowerLogGroupName(trailsWithLogGroup, region);
 };
 
+export const resolveControlTowerCloudTrailLogGroupName = resolveCloudTrailLogGroupName;
+
 const buildMissingConfigError = (region: string, originalError: Error): Error => {
   const message =
     `Unable to resolve the Control Tower CloudTrail log group in ${region}. ` +

--- a/src/core/accelerator/config/cloudtrail.ts
+++ b/src/core/accelerator/config/cloudtrail.ts
@@ -1,15 +1,7 @@
-import fs from 'node:fs';
-import path from 'node:path';
 import { CloudTrailClient, DescribeTrailsCommand } from '@aws-sdk/client-cloudtrail';
-import { loadConfigSync } from '../../../config';
-import { resolveProjectPath } from '../../util/path';
-
-const AUTO_LOG_GROUP_PLACEHOLDER = '__AUTO__';
-const SECURITY_CONFIG_FILE = 'security-config.yaml';
+import { Trail } from '@aws-sdk/client-cloudtrail/dist-types/models/models_0';
 
 const CONTROL_TOWER_LOG_GROUP_PREFIX = 'aws-controltower/CloudTrailLogs';
-
-type TrailEntry = { trail: { IsOrganizationTrail?: boolean }; logGroupName: string };
 
 const parseLogGroupName = (arn: string): string | null => {
   const marker = ':log-group:';
@@ -21,122 +13,26 @@ const parseLogGroupName = (arn: string): string | null => {
   return name || null;
 };
 
-const extractTrailLogGroups = (trails: Array<{ CloudWatchLogsLogGroupArn?: string; IsOrganizationTrail?: boolean }>): TrailEntry[] => {
-  const candidates: TrailEntry[] = [];
-  for (const trail of trails) {
-    const arn = trail.CloudWatchLogsLogGroupArn;
-    if (!arn) {
-      continue;
-    }
-    const logGroupName = parseLogGroupName(arn);
-    if (!logGroupName) {
-      continue;
-    }
-    candidates.push({ trail, logGroupName });
+const findControlTowerLogGroupName = (trails: Trail[]): string | null => {
+  const organizationTrail = trails.find(trailEntry =>
+    trailEntry.CloudWatchLogsLogGroupArn?.includes(CONTROL_TOWER_LOG_GROUP_PREFIX) && trailEntry.IsOrganizationTrail,
+  );
+  if (!organizationTrail || !organizationTrail.CloudWatchLogsLogGroupArn) {
+    return null;
   }
-  return candidates;
+
+  return parseLogGroupName(organizationTrail.CloudWatchLogsLogGroupArn);
 };
 
-const isControlTowerLogGroup = (entry: TrailEntry): boolean =>
-  entry.logGroupName.startsWith(CONTROL_TOWER_LOG_GROUP_PREFIX);
-
-const selectControlTowerLogGroupName = (trailCandidates: TrailEntry[], region: string): string => {
-  const controlTowerCandidates = trailCandidates.filter(isControlTowerLogGroup);
-
-  if (controlTowerCandidates.length === 1) {
-    return controlTowerCandidates[0].logGroupName;
-  }
-
-  const controlTowerOrganizationCandidates = controlTowerCandidates.filter(
-    (entry) => entry.trail.IsOrganizationTrail === true,
-  );
-  if (controlTowerOrganizationCandidates.length === 1) {
-    return controlTowerOrganizationCandidates[0].logGroupName;
-  }
-
-  if (controlTowerCandidates.length === 0) {
-    throw new Error(`Unable to find a Control Tower CloudTrail log group in ${region}.`);
-  }
-
-  throw new Error(
-    `Found multiple Control Tower CloudTrail log groups in ${region}. ` +
-    'Set cloudTrailLogGroupName explicitly in config.ts and re-run deploy.',
-  );
-};
-
-const resolveCloudTrailLogGroupName = async (region: string): Promise<string> => {
-  const client = new CloudTrailClient({ region });
-  const response = await client.send(new DescribeTrailsCommand({
+export const resolveControlTowerCloudTrailLogGroupName = async (region: string): Promise<string> => {
+  const cloudTrailClient = new CloudTrailClient({ region });
+  const commandOutput = await cloudTrailClient.send(new DescribeTrailsCommand({
     includeShadowTrails: false,
   }));
-  const trails = response.trailList || [];
-  const trailsWithLogGroup = extractTrailLogGroups(trails);
-
-  return selectControlTowerLogGroupName(trailsWithLogGroup, region);
-};
-
-export const resolveControlTowerCloudTrailLogGroupName = resolveCloudTrailLogGroupName;
-
-const buildMissingConfigError = (region: string, originalError: Error): Error => {
-  const message =
-    `Unable to resolve the Control Tower CloudTrail log group in ${region}. ` +
-    'Set cloudTrailLogGroupName explicitly in config.ts and re-run deploy.';
-
-  return new Error(`${message} Cause: ${originalError.message}`);
-};
-
-const toError = (value: unknown): Error => {
-  if (value instanceof Error) {
-    return value;
+  const trails = commandOutput.trailList || [];
+  const controlTowerLogGroupName = findControlTowerLogGroupName(trails);
+  if (controlTowerLogGroupName === null) {
+    throw new Error(`Unable to find a Control Tower CloudTrail log group in ${region}.`);
   }
-  return new Error(String(value));
-};
-
-const replaceAutoPlaceholder = (contents: string, value: string): string => {
-  return contents.split(AUTO_LOG_GROUP_PLACEHOLDER).join(value);
-};
-
-const resolveSecurityConfigPath = (configOutDir: string): string => {
-  return path.join(configOutDir, SECURITY_CONFIG_FILE);
-};
-
-const readSecurityConfig = (configOutDir: string, configOutPathForError: string): string => {
-  const securityConfigPath = resolveSecurityConfigPath(configOutDir);
-  if (!fs.existsSync(securityConfigPath)) {
-    throw new Error(
-      `Expected ${SECURITY_CONFIG_FILE} in ${configOutPathForError}. Run synth before deploy.`,
-    );
-  }
-  return fs.readFileSync(securityConfigPath, 'utf8');
-};
-
-const writeSecurityConfig = (configOutDir: string, contents: string): void => {
-  const securityConfigPath = resolveSecurityConfigPath(configOutDir);
-  fs.writeFileSync(securityConfigPath, contents);
-};
-
-export const applyAutoCloudTrailLogGroupName = async (): Promise<void> => {
-  const config = loadConfigSync();
-  if (config.cloudTrailLogGroupName !== AUTO_LOG_GROUP_PLACEHOLDER) {
-    return;
-  }
-
-  const acceleratorConfigOutDir = resolveProjectPath(config.awsAcceleratorConfigOutPath);
-  const securityConfigContents = readSecurityConfig(
-    acceleratorConfigOutDir,
-    config.awsAcceleratorConfigOutPath,
-  );
-  if (!securityConfigContents.includes(AUTO_LOG_GROUP_PLACEHOLDER)) {
-    return;
-  }
-
-  let logGroupName: string;
-  try {
-    logGroupName = await resolveCloudTrailLogGroupName(config.homeRegion);
-  } catch (error) {
-    throw buildMissingConfigError(config.homeRegion, toError(error));
-  }
-
-  const updated = replaceAutoPlaceholder(securityConfigContents, logGroupName);
-  writeSecurityConfig(acceleratorConfigOutDir, updated);
+  return controlTowerLogGroupName;
 };

--- a/src/core/accelerator/config/cloudtrail.ts
+++ b/src/core/accelerator/config/cloudtrail.ts
@@ -1,5 +1,4 @@
-import { CloudTrailClient, DescribeTrailsCommand } from '@aws-sdk/client-cloudtrail';
-import { Trail } from '@aws-sdk/client-cloudtrail/dist-types/models/models_0';
+import { CloudTrailClient, DescribeTrailsCommand, Trail } from '@aws-sdk/client-cloudtrail';
 
 const CONTROL_TOWER_LOG_GROUP_PREFIX = 'aws-controltower/CloudTrailLogs';
 
@@ -24,6 +23,17 @@ const findControlTowerLogGroupName = (trails: Trail[]): string | null => {
   return parseLogGroupName(organizationTrail.CloudWatchLogsLogGroupArn);
 };
 
+/**
+ * Resolves the Control Tower CloudTrail log group name from the given region.
+ *
+ * The `region` parameter should be the Control Tower home region, as that is
+ * where the organization-level CloudTrail trail is created. Passing a different
+ * region will result in an error if no matching trail is found there.
+ *
+ * @param region - The AWS region to look up the Control Tower CloudTrail trail in (should be the CT home region).
+ * @returns The CloudWatch log group name associated with the Control Tower organization trail.
+ * @throws If no matching organization trail with a Control Tower log group is found.
+ */
 export const resolveControlTowerCloudTrailLogGroupName = async (region: string): Promise<string> => {
   const cloudTrailClient = new CloudTrailClient({ region });
   const commandOutput = await cloudTrailClient.send(new DescribeTrailsCommand({

--- a/src/core/blueprint/blueprint.ts
+++ b/src/core/blueprint/blueprint.ts
@@ -4,6 +4,8 @@ import * as organizations from '@aws-sdk/client-organizations';
 import * as ssoAdmin from '@aws-sdk/client-sso-admin';
 import * as sts from '@aws-sdk/client-sts';
 import { Liquid } from 'liquidjs';
+import { assertInitControlTowerPrerequisites } from './init-prechecks';
+import { resolveControlTowerCloudTrailLogGroupName } from '../accelerator/config/cloudtrail';
 import { getVersion } from '../accelerator/installer/installer';
 import { resolveProjectPath } from '../util/path';
 
@@ -63,10 +65,12 @@ export const renderBlueprint = async (blueprintName: string, { forceOverwrite, a
   region: string;
 }) => {
   const managementAccountId = await getAwsAccountId(region);
+  await assertInitControlTowerPrerequisites(region, managementAccountId);
   const installerVersion = await getVersion(region);
   const organizationId = await getOrganizationId(region);
   const rootOuId = await getRootOuId(region);
   const identityStoreId = await getIdentityStoreId(region);
+  const cloudTrailLogGroupName = await resolveControlTowerCloudTrailLogGroupName(region);
 
   const projectRoot = resolveProjectPath();
   const blueprintRoot = buildBlueprintPath(blueprintName);
@@ -110,6 +114,7 @@ export const renderBlueprint = async (blueprintName: string, { forceOverwrite, a
           AWS_ACCOUNTS_ROOT_EMAIL: accountsRootEmail,
           AWS_HOME_REGION: region,
           AWS_IDENTITY_STORE_ID: identityStoreId,
+          AWS_CLOUDTRAIL_LOG_GROUP_NAME: cloudTrailLogGroupName,
         },
       );
       // if a target file already exists, skip it until force overwrite is enabled

--- a/src/core/blueprint/blueprint.ts
+++ b/src/core/blueprint/blueprint.ts
@@ -4,7 +4,7 @@ import * as organizations from '@aws-sdk/client-organizations';
 import * as ssoAdmin from '@aws-sdk/client-sso-admin';
 import * as sts from '@aws-sdk/client-sts';
 import { Liquid } from 'liquidjs';
-import { assertInitControlTowerPrerequisites } from './init-prechecks';
+import { isControlTowerRolloutComplete } from './init-prechecks';
 import { resolveControlTowerCloudTrailLogGroupName } from '../accelerator/config/cloudtrail';
 import { getVersion } from '../accelerator/installer/installer';
 import { resolveProjectPath } from '../util/path';
@@ -65,7 +65,11 @@ export const renderBlueprint = async (blueprintName: string, { forceOverwrite, a
   region: string;
 }) => {
   const managementAccountId = await getAwsAccountId(region);
-  await assertInitControlTowerPrerequisites(region, managementAccountId);
+  if (!await isControlTowerRolloutComplete(managementAccountId)) {
+    throw new Error(
+      'Control Tower/LZA initial rollout is not complete yet. Finish rollout before running init.',
+    );
+  }
   const installerVersion = await getVersion(region);
   const organizationId = await getOrganizationId(region);
   const rootOuId = await getRootOuId(region);

--- a/src/core/blueprint/blueprint.ts
+++ b/src/core/blueprint/blueprint.ts
@@ -4,7 +4,7 @@ import * as organizations from '@aws-sdk/client-organizations';
 import * as ssoAdmin from '@aws-sdk/client-sso-admin';
 import * as sts from '@aws-sdk/client-sts';
 import { Liquid } from 'liquidjs';
-import { isControlTowerRolloutComplete } from './init-prechecks';
+import { isLzaRolloutComplete } from './init-prechecks';
 import { resolveControlTowerCloudTrailLogGroupName } from '../accelerator/config/cloudtrail';
 import { getVersion } from '../accelerator/installer/installer';
 import { resolveProjectPath } from '../util/path';
@@ -65,7 +65,7 @@ export const renderBlueprint = async (blueprintName: string, { forceOverwrite, a
   region: string;
 }) => {
   const managementAccountId = await getAwsAccountId(region);
-  if (!await isControlTowerRolloutComplete(managementAccountId)) {
+  if (!await isLzaRolloutComplete(managementAccountId)) {
     throw new Error(
       'Control Tower/LZA initial rollout is not complete yet. Finish rollout before running init.',
     );

--- a/src/core/blueprint/init-prechecks.ts
+++ b/src/core/blueprint/init-prechecks.ts
@@ -1,0 +1,166 @@
+import * as ssm from '@aws-sdk/client-ssm';
+
+const ACCELERATOR_PREFIX_SSM_PARAMETER_NAME = '/accelerator/lza-prefix';
+const COMMERCIAL_GLOBAL_REGION = 'us-east-1';
+const GOVERNMENT_GLOBAL_REGION = 'us-gov-west-1';
+const CHINA_GLOBAL_REGION = 'cn-northwest-1';
+
+type ParameterLookupError = Error & {
+  name: string;
+  Code?: string;
+  code?: string;
+  message: string;
+};
+
+const toFinalizeStackVersionSsmParameterName = (
+  acceleratorPrefix: string,
+  accountId: string,
+  region: string,
+): string => {
+  const oneWordPrefix = acceleratorPrefix.toLowerCase() === 'awsaccelerator'
+    ? 'accelerator'
+    : acceleratorPrefix;
+  return `/${oneWordPrefix}/${acceleratorPrefix}-FinalizeStack-${accountId}-${region}/version`;
+};
+
+const resolveGlobalRegionForHomeRegion = (region: string): string => {
+  if (region.startsWith('cn-')) {
+    return CHINA_GLOBAL_REGION;
+  }
+  if (region.startsWith('us-gov-')) {
+    return GOVERNMENT_GLOBAL_REGION;
+  }
+  return COMMERCIAL_GLOBAL_REGION;
+};
+
+type FinalizeMarkerCandidate = {
+  region: string;
+  parameterName: string;
+};
+
+const toFinalizeStackVersionCandidates = (
+  acceleratorPrefix: string,
+  accountId: string,
+  homeRegion: string,
+): FinalizeMarkerCandidate[] => {
+  const globalRegion = resolveGlobalRegionForHomeRegion(homeRegion);
+  const regions = homeRegion === globalRegion
+    ? [homeRegion]
+    : [homeRegion, globalRegion];
+
+  return regions.map(region => ({
+    region,
+    parameterName: toFinalizeStackVersionSsmParameterName(acceleratorPrefix, accountId, region),
+  }));
+};
+
+const toParameterLookupError = (error: unknown): ParameterLookupError | null => {
+  if (error instanceof Error) {
+    return error;
+  }
+  if (typeof error === 'object' && error !== null) {
+    const candidate = error as {
+      name?: string;
+      Code?: string;
+      code?: string;
+      message?: string;
+    };
+    return {
+      name: candidate.name ?? '',
+      Code: candidate.Code,
+      code: candidate.code,
+      message: candidate.message ?? '',
+    };
+  }
+  return null;
+};
+
+const isParameterNotFound = (error: unknown): boolean => {
+  const normalizedError = toParameterLookupError(error);
+  if (!normalizedError) {
+    return false;
+  }
+  const name = normalizedError.name ?? '';
+  const code = normalizedError.Code ?? normalizedError.code ?? '';
+  const message = normalizedError.message;
+  const normalizedMessage = message.toLowerCase();
+
+  return name === 'ParameterNotFound'
+    || code === 'ParameterNotFound'
+    || message.includes('ParameterNotFound')
+    || normalizedMessage.includes('parameter not found');
+};
+
+const readRequiredSsmStringParameter = async (
+  client: ssm.SSMClient,
+  parameterName: string,
+  missingMessage: string,
+): Promise<string> => {
+  try {
+    const result = await client.send(new ssm.GetParameterCommand({ Name: parameterName }));
+    const value = result.Parameter?.Value;
+    if (!value) {
+      throw new Error(`SSM parameter ${parameterName} is empty.`);
+    }
+    return value;
+  } catch (error) {
+    if (isParameterNotFound(error)) {
+      throw new Error(missingMessage);
+    }
+    throw error;
+  }
+};
+
+const readAcceleratorPrefixSsmParameter = async (client: ssm.SSMClient): Promise<string> => {
+  return readRequiredSsmStringParameter(
+    client,
+    ACCELERATOR_PREFIX_SSM_PARAMETER_NAME,
+    `Missing required SSM parameter ${ACCELERATOR_PREFIX_SSM_PARAMETER_NAME}. ` +
+    'Control Tower/LZA initial rollout does not look complete yet. ' +
+    'Finish the initial rollout before running init.',
+  );
+};
+
+const assertFinalizeStackVersionMarkerExists = async (
+  homeRegion: string,
+  managementAccountId: string,
+  acceleratorPrefix: string,
+): Promise<void> => {
+  const finalizeVersionCandidates = toFinalizeStackVersionCandidates(
+    acceleratorPrefix,
+    managementAccountId,
+    homeRegion,
+  );
+  for (const candidate of finalizeVersionCandidates) {
+    const parameterName = candidate.parameterName;
+    const region = candidate.region;
+    const regionalClient = new ssm.SSMClient({ region });
+    try {
+      const result = await regionalClient.send(new ssm.GetParameterCommand({ Name: parameterName }));
+      const value = result.Parameter?.Value;
+      if (!value) {
+        throw new Error(`SSM parameter ${parameterName} is empty.`);
+      }
+      return;
+    } catch (error) {
+      if (!isParameterNotFound(error)) {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error(
+    `Missing required finalize marker parameter. Checked ${finalizeVersionCandidates.map(candidate => candidate.parameterName).join(', ')}. ` +
+    'Control Tower/LZA initial rollout is not complete yet. ' +
+    'Finish rollout before running init.',
+  );
+};
+
+export const assertInitControlTowerPrerequisites = async (
+  region: string,
+  managementAccountId: string,
+): Promise<void> => {
+  const client = new ssm.SSMClient({ region });
+  const acceleratorPrefix = await readAcceleratorPrefixSsmParameter(client);
+  await assertFinalizeStackVersionMarkerExists(region, managementAccountId, acceleratorPrefix);
+};

--- a/src/core/blueprint/init-prechecks.ts
+++ b/src/core/blueprint/init-prechecks.ts
@@ -1,166 +1,22 @@
 import * as ssm from '@aws-sdk/client-ssm';
+import { ParameterNotFound } from '@aws-sdk/client-ssm';
+import { GLOBAL_REGION } from './../../config';
 
-const ACCELERATOR_PREFIX_SSM_PARAMETER_NAME = '/accelerator/lza-prefix';
-const COMMERCIAL_GLOBAL_REGION = 'us-east-1';
-const GOVERNMENT_GLOBAL_REGION = 'us-gov-west-1';
-const CHINA_GLOBAL_REGION = 'cn-northwest-1';
-
-type ParameterLookupError = Error & {
-  name: string;
-  Code?: string;
-  code?: string;
-  message: string;
-};
-
-const toFinalizeStackVersionSsmParameterName = (
-  acceleratorPrefix: string,
-  accountId: string,
-  region: string,
-): string => {
-  const oneWordPrefix = acceleratorPrefix.toLowerCase() === 'awsaccelerator'
-    ? 'accelerator'
-    : acceleratorPrefix;
-  return `/${oneWordPrefix}/${acceleratorPrefix}-FinalizeStack-${accountId}-${region}/version`;
-};
-
-const resolveGlobalRegionForHomeRegion = (region: string): string => {
-  if (region.startsWith('cn-')) {
-    return CHINA_GLOBAL_REGION;
-  }
-  if (region.startsWith('us-gov-')) {
-    return GOVERNMENT_GLOBAL_REGION;
-  }
-  return COMMERCIAL_GLOBAL_REGION;
-};
-
-type FinalizeMarkerCandidate = {
-  region: string;
-  parameterName: string;
-};
-
-const toFinalizeStackVersionCandidates = (
-  acceleratorPrefix: string,
-  accountId: string,
-  homeRegion: string,
-): FinalizeMarkerCandidate[] => {
-  const globalRegion = resolveGlobalRegionForHomeRegion(homeRegion);
-  const regions = homeRegion === globalRegion
-    ? [homeRegion]
-    : [homeRegion, globalRegion];
-
-  return regions.map(region => ({
-    region,
-    parameterName: toFinalizeStackVersionSsmParameterName(acceleratorPrefix, accountId, region),
-  }));
-};
-
-const toParameterLookupError = (error: unknown): ParameterLookupError | null => {
-  if (error instanceof Error) {
-    return error;
-  }
-  if (typeof error === 'object' && error !== null) {
-    const candidate = error as {
-      name?: string;
-      Code?: string;
-      code?: string;
-      message?: string;
-    };
-    return {
-      name: candidate.name ?? '',
-      Code: candidate.Code,
-      code: candidate.code,
-      message: candidate.message ?? '',
-    };
-  }
-  return null;
-};
-
-const isParameterNotFound = (error: unknown): boolean => {
-  const normalizedError = toParameterLookupError(error);
-  if (!normalizedError) {
-    return false;
-  }
-  const name = normalizedError.name ?? '';
-  const code = normalizedError.Code ?? normalizedError.code ?? '';
-  const message = normalizedError.message;
-  const normalizedMessage = message.toLowerCase();
-
-  return name === 'ParameterNotFound'
-    || code === 'ParameterNotFound'
-    || message.includes('ParameterNotFound')
-    || normalizedMessage.includes('parameter not found');
-};
-
-const readRequiredSsmStringParameter = async (
-  client: ssm.SSMClient,
-  parameterName: string,
-  missingMessage: string,
-): Promise<string> => {
+export const isControlTowerRolloutComplete = async (
+  managementAccountId: string,
+): Promise<boolean> => {
+  const finalizeStackParameterName = `/accelerator/AWSAccelerator-FinalizeStack-${managementAccountId}-${GLOBAL_REGION}/version`;
+  const globalRegionSSMClient = new ssm.SSMClient({ region: GLOBAL_REGION });
   try {
-    const result = await client.send(new ssm.GetParameterCommand({ Name: parameterName }));
-    const value = result.Parameter?.Value;
-    if (!value) {
-      throw new Error(`SSM parameter ${parameterName} is empty.`);
+    const commandOutput = await globalRegionSSMClient.send(new ssm.GetParameterCommand({ Name: finalizeStackParameterName }));
+    if (commandOutput.Parameter?.Value) {
+      return true;
     }
-    return value;
   } catch (error) {
-    if (isParameterNotFound(error)) {
-      throw new Error(missingMessage);
+    if (error instanceof ParameterNotFound) {
+      return false;
     }
     throw error;
   }
-};
-
-const readAcceleratorPrefixSsmParameter = async (client: ssm.SSMClient): Promise<string> => {
-  return readRequiredSsmStringParameter(
-    client,
-    ACCELERATOR_PREFIX_SSM_PARAMETER_NAME,
-    `Missing required SSM parameter ${ACCELERATOR_PREFIX_SSM_PARAMETER_NAME}. ` +
-    'Control Tower/LZA initial rollout does not look complete yet. ' +
-    'Finish the initial rollout before running init.',
-  );
-};
-
-const assertFinalizeStackVersionMarkerExists = async (
-  homeRegion: string,
-  managementAccountId: string,
-  acceleratorPrefix: string,
-): Promise<void> => {
-  const finalizeVersionCandidates = toFinalizeStackVersionCandidates(
-    acceleratorPrefix,
-    managementAccountId,
-    homeRegion,
-  );
-  for (const candidate of finalizeVersionCandidates) {
-    const parameterName = candidate.parameterName;
-    const region = candidate.region;
-    const regionalClient = new ssm.SSMClient({ region });
-    try {
-      const result = await regionalClient.send(new ssm.GetParameterCommand({ Name: parameterName }));
-      const value = result.Parameter?.Value;
-      if (!value) {
-        throw new Error(`SSM parameter ${parameterName} is empty.`);
-      }
-      return;
-    } catch (error) {
-      if (!isParameterNotFound(error)) {
-        throw error;
-      }
-    }
-  }
-
-  throw new Error(
-    `Missing required finalize marker parameter. Checked ${finalizeVersionCandidates.map(candidate => candidate.parameterName).join(', ')}. ` +
-    'Control Tower/LZA initial rollout is not complete yet. ' +
-    'Finish rollout before running init.',
-  );
-};
-
-export const assertInitControlTowerPrerequisites = async (
-  region: string,
-  managementAccountId: string,
-): Promise<void> => {
-  const client = new ssm.SSMClient({ region });
-  const acceleratorPrefix = await readAcceleratorPrefixSsmParameter(client);
-  await assertFinalizeStackVersionMarkerExists(region, managementAccountId, acceleratorPrefix);
+  return false;
 };

--- a/src/core/blueprint/init-prechecks.ts
+++ b/src/core/blueprint/init-prechecks.ts
@@ -1,8 +1,19 @@
 import * as ssm from '@aws-sdk/client-ssm';
 import { ParameterNotFound } from '@aws-sdk/client-ssm';
-import { GLOBAL_REGION } from './../../config';
+import { GLOBAL_REGION } from '../../config';
 
-export const isControlTowerRolloutComplete = async (
+/**
+ * Checks whether the LZA/Control Tower rollout is complete by verifying
+ * that the AWSAccelerator-FinalizeStack SSM parameter exists in the global region (us-east-1).
+ *
+ * The FinalizeStack always deploys to us-east-1 regardless of the user-supplied --region,
+ * which is why this check is intentionally scoped to GLOBAL_REGION.
+ *
+ * @param managementAccountId - The AWS management account ID.
+ * @returns `true` if the FinalizeStack SSM parameter exists and has a value, `false` if not found.
+ * @throws If the SSM call fails for a reason other than ParameterNotFound.
+ */
+export const isLzaRolloutComplete = async (
   managementAccountId: string,
 ): Promise<boolean> => {
   const finalizeStackParameterName = `/accelerator/AWSAccelerator-FinalizeStack-${managementAccountId}-${GLOBAL_REGION}/version`;

--- a/test/commands/__snapshots__/init.test.ts.snap
+++ b/test/commands/__snapshots__/init.test.ts.snap
@@ -49,9 +49,9 @@ export const ENABLED_REGIONS = [GLOBAL_REGION, HOME_REGION];
 
 /**
  * The CloudTrail log group that Control Tower creates in the home region.
- * Use '__AUTO__' to resolve it during deployment.
+ * This value is resolved during \`init\` when initial rollout prerequisites are available.
  */
-export const CLOUDTRAIL_LOG_GROUP_NAME = '__AUTO__';
+export const CLOUDTRAIL_LOG_GROUP_NAME = 'aws-controltower/CloudTrailLogs-xyz';
 
 /**
  * The groups should be aligned with the groups in the AWS IAM Identity Center.

--- a/test/commands/__snapshots__/init.test.ts.snap
+++ b/test/commands/__snapshots__/init.test.ts.snap
@@ -49,7 +49,6 @@ export const ENABLED_REGIONS = [GLOBAL_REGION, HOME_REGION];
 
 /**
  * The CloudTrail log group that Control Tower creates in the home region.
- * This value is resolved during \`init\` when initial rollout prerequisites are available.
  */
 export const CLOUDTRAIL_LOG_GROUP_NAME = 'aws-controltower/CloudTrailLogs-xyz';
 

--- a/test/commands/__snapshots__/init.test.ts.snap
+++ b/test/commands/__snapshots__/init.test.ts.snap
@@ -309,6 +309,7 @@ export const config: Config = {
   homeRegion: HOME_REGION,
   enabledRegions: ENABLED_REGIONS,
   awsAcceleratorVersion: AWS_ACCELERATOR_VERSION,
+  cloudTrailLogGroupName: CLOUDTRAIL_LOG_GROUP_NAME,
 };
 "
 `;

--- a/test/commands/__snapshots__/init.test.ts.snap
+++ b/test/commands/__snapshots__/init.test.ts.snap
@@ -308,7 +308,6 @@ export const config: Config = {
   managementAccountId: MANAGEMENT_ACCOUNT_ID,
   homeRegion: HOME_REGION,
   enabledRegions: ENABLED_REGIONS,
-  cloudTrailLogGroupName: CLOUDTRAIL_LOG_GROUP_NAME,
   awsAcceleratorVersion: AWS_ACCELERATOR_VERSION,
 };
 "

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { CloudTrailClient, DescribeTrailsCommand } from '@aws-sdk/client-cloudtrail';
 import { OrganizationsClient, DescribeOrganizationCommand, ListRootsCommand } from '@aws-sdk/client-organizations';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
 import { SSOAdminClient, ListInstancesCommand } from '@aws-sdk/client-sso-admin';
@@ -25,6 +26,75 @@ describe('Init Command', () => {
   const orgMock = mockClient(OrganizationsClient);
   const ssoMock = mockClient(SSOAdminClient);
   const ssmMock = mockClient(SSMClient);
+  const cloudTrailMock = mockClient(CloudTrailClient);
+  const LZA_PREFIX_PARAMETER_NAME = '/accelerator/lza-prefix';
+  const FINALIZE_VERSION_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${TEST_REGION}/version`;
+  const EU_HOME_REGION = 'eu-central-1';
+  const EU_FINALIZE_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${EU_HOME_REGION}/version`;
+  const US_GOV_HOME_REGION = 'us-gov-east-1';
+  const US_GOV_FINALIZE_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-us-gov-west-1/version`;
+  const CN_HOME_REGION = 'cn-north-1';
+  const CN_FINALIZE_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-cn-northwest-1/version`;
+  const US_GOV_HOME_FINALIZE_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${US_GOV_HOME_REGION}/version`;
+  const CN_HOME_FINALIZE_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${CN_HOME_REGION}/version`;
+  const FINALIZE_PARAMETER_VALUE = TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2;
+
+  const mockLzaPrefixParameter = () => {
+    ssmMock.on(GetParameterCommand, {
+      Name: LZA_PREFIX_PARAMETER_NAME,
+    }).resolves({
+      Parameter: {
+        Name: LZA_PREFIX_PARAMETER_NAME,
+        Value: 'AWSAccelerator',
+        Type: 'String',
+      },
+    });
+  };
+
+  const mockInstallerVersionParameter = () => {
+    ssmMock.on(GetParameterCommand, {
+      Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
+    }).resolves({
+      Parameter: {
+        Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
+        Value: TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2,
+        Type: 'String',
+      },
+    });
+  };
+
+  const mockFinalizeVersionParameter = (parameterName: string, value: string) => {
+    ssmMock.on(GetParameterCommand, {
+      Name: parameterName,
+    }).resolves({
+      Parameter: {
+        Name: parameterName,
+        Value: value,
+        Type: 'String',
+      },
+    });
+  };
+
+  const mockFinalizeNotFound = (parameterName: string) => {
+    ssmMock.on(GetParameterCommand, {
+      Name: parameterName,
+    }).rejects(new Error('ParameterNotFound'));
+  };
+
+  const resetSsmInitBase = () => {
+    ssmMock.reset();
+    mockLzaPrefixParameter();
+    mockInstallerVersionParameter();
+  };
+
+  const runInit = (region: string) => {
+    const cli = createCliFor(Init);
+    return runCli(cli, [
+      'init',
+      '--region', region,
+      '--accounts-root-email', TEST_EMAIL,
+    ], temp);
+  };
 
   beforeEach(() => {
     temp = useTempDir();
@@ -34,6 +104,7 @@ describe('Init Command', () => {
     orgMock.reset();
     ssoMock.reset();
     ssmMock.reset();
+    cloudTrailMock.reset();
 
     stsMock.on(GetCallerIdentityCommand).resolves({
       Account: TEST_ACCOUNT_ID,
@@ -72,12 +143,16 @@ describe('Init Command', () => {
       ],
     });
 
-    ssmMock.on(GetParameterCommand).resolves({
-      Parameter: {
-        Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
-        Value: TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2,
-        Type: 'String',
-      },
+    mockLzaPrefixParameter();
+    mockFinalizeVersionParameter(FINALIZE_VERSION_PARAMETER_NAME, FINALIZE_PARAMETER_VALUE);
+    mockInstallerVersionParameter();
+    cloudTrailMock.on(DescribeTrailsCommand).resolves({
+      trailList: [
+        {
+          IsOrganizationTrail: true,
+          CloudWatchLogsLogGroupArn: `arn:aws:logs:${TEST_REGION}:${TEST_ACCOUNT_ID}:log-group:aws-controltower/CloudTrailLogs-xyz`,
+        },
+      ],
     });
   });
 
@@ -101,4 +176,63 @@ describe('Init Command', () => {
     const configContent = fs.readFileSync(configPath, 'utf8');
     expect(configContent).toMatchSnapshot();
   });
+
+  it('should fail when finalize marker parameter is missing', async () => {
+    mockFinalizeNotFound(FINALIZE_VERSION_PARAMETER_NAME);
+    await expect(runInit(TEST_REGION)).rejects.toThrow();
+
+    expect(fs.existsSync(path.join(temp.directory, 'config.ts'))).toBe(false);
+  });
+
+  it('should initialize when finalize marker exists only in global region for a non-global home region', async () => {
+    resetSsmInitBase();
+    mockFinalizeNotFound(EU_FINALIZE_PARAMETER_NAME);
+    mockFinalizeVersionParameter(FINALIZE_VERSION_PARAMETER_NAME, FINALIZE_PARAMETER_VALUE);
+    await runInit(EU_HOME_REGION);
+
+    expect(fs.existsSync(path.join(temp.directory, 'config.ts'))).toBe(true);
+  });
+
+  it('should fail with both checked finalize parameter paths when marker is missing in home and global region', async () => {
+    resetSsmInitBase();
+    mockFinalizeNotFound(EU_FINALIZE_PARAMETER_NAME);
+    mockFinalizeNotFound(FINALIZE_VERSION_PARAMETER_NAME);
+    await expect(runInit(EU_HOME_REGION)).rejects.toThrow();
+    expect(ssmMock).toHaveReceivedCommandTimes(GetParameterCommand, 3);
+    expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
+      Name: EU_FINALIZE_PARAMETER_NAME,
+    });
+    expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
+      Name: FINALIZE_VERSION_PARAMETER_NAME,
+    });
+  });
+
+  it('should fail when finalize marker exists but has an empty value', async () => {
+    resetSsmInitBase();
+    mockFinalizeVersionParameter(FINALIZE_VERSION_PARAMETER_NAME, '');
+    await expect(runInit(TEST_REGION)).rejects.toThrow();
+    expect(ssmMock).toHaveReceivedCommandTimes(GetParameterCommand, 2);
+    expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
+      Name: FINALIZE_VERSION_PARAMETER_NAME,
+    });
+  });
+
+  it('should initialize when us-gov home region uses us-gov-west-1 finalize marker fallback', async () => {
+    resetSsmInitBase();
+    mockFinalizeNotFound(US_GOV_HOME_FINALIZE_PARAMETER_NAME);
+    mockFinalizeVersionParameter(US_GOV_FINALIZE_PARAMETER_NAME, FINALIZE_PARAMETER_VALUE);
+    await runInit(US_GOV_HOME_REGION);
+
+    expect(fs.existsSync(path.join(temp.directory, 'config.ts'))).toBe(true);
+  });
+
+  it('should initialize when cn home region uses cn-northwest-1 finalize marker fallback', async () => {
+    resetSsmInitBase();
+    mockFinalizeNotFound(CN_HOME_FINALIZE_PARAMETER_NAME);
+    mockFinalizeVersionParameter(CN_FINALIZE_PARAMETER_NAME, FINALIZE_PARAMETER_VALUE);
+    await runInit(CN_HOME_REGION);
+
+    expect(fs.existsSync(path.join(temp.directory, 'config.ts'))).toBe(true);
+  });
+
 });

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -161,29 +161,33 @@ describe('Init Command', () => {
   it('should fail when finalize marker parameter is missing', async () => {
     resetSsmInitBase();
     mockFinalizeNotFound(FINALIZE_VERSION_PARAMETER_NAME);
+
     await expect(runInit(TEST_REGION)).rejects.toThrow();
+
     expect(ssmMock).toHaveReceivedCommandTimes(GetParameterCommand, 1);
     expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
       Name: FINALIZE_VERSION_PARAMETER_NAME,
     });
-
     expect(fs.existsSync(path.join(temp.directory, 'config.ts'))).toBe(false);
   });
 
   it('should initialize when global finalize marker exists for a non-global home region', async () => {
     resetSsmInitBase();
+
     await runInit(EU_HOME_REGION);
+
     expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
       Name: FINALIZE_VERSION_PARAMETER_NAME,
     });
-
     expect(fs.existsSync(path.join(temp.directory, 'config.ts'))).toBe(true);
   });
 
   it('should fail when global finalize marker is missing for a non-global home region', async () => {
     resetSsmInitBase();
     mockFinalizeNotFound(FINALIZE_VERSION_PARAMETER_NAME);
+
     await expect(runInit(EU_HOME_REGION)).rejects.toThrow();
+
     expect(ssmMock).toHaveReceivedCommandTimes(GetParameterCommand, 1);
     expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
       Name: FINALIZE_VERSION_PARAMETER_NAME,
@@ -193,7 +197,9 @@ describe('Init Command', () => {
   it('should fail when finalize marker exists but has an empty value', async () => {
     resetSsmInitBase();
     mockFinalizeVersionParameter(FINALIZE_VERSION_PARAMETER_NAME, '');
+
     await expect(runInit(TEST_REGION)).rejects.toThrow();
+
     expect(ssmMock).toHaveReceivedCommandTimes(GetParameterCommand, 1);
     expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
       Name: FINALIZE_VERSION_PARAMETER_NAME,

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { CloudTrailClient, DescribeTrailsCommand } from '@aws-sdk/client-cloudtrail';
 import { OrganizationsClient, DescribeOrganizationCommand, ListRootsCommand } from '@aws-sdk/client-organizations';
-import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { SSMClient, GetParameterCommand, ParameterNotFound } from '@aws-sdk/client-ssm';
 import { SSOAdminClient, ListInstancesCommand } from '@aws-sdk/client-sso-admin';
 import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -27,29 +27,11 @@ describe('Init Command', () => {
   const ssoMock = mockClient(SSOAdminClient);
   const ssmMock = mockClient(SSMClient);
   const cloudTrailMock = mockClient(CloudTrailClient);
-  const LZA_PREFIX_PARAMETER_NAME = '/accelerator/lza-prefix';
   const FINALIZE_VERSION_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${TEST_REGION}/version`;
   const EU_HOME_REGION = 'eu-central-1';
-  const EU_FINALIZE_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${EU_HOME_REGION}/version`;
   const US_GOV_HOME_REGION = 'us-gov-east-1';
-  const US_GOV_FINALIZE_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-us-gov-west-1/version`;
   const CN_HOME_REGION = 'cn-north-1';
-  const CN_FINALIZE_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-cn-northwest-1/version`;
-  const US_GOV_HOME_FINALIZE_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${US_GOV_HOME_REGION}/version`;
-  const CN_HOME_FINALIZE_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${CN_HOME_REGION}/version`;
   const FINALIZE_PARAMETER_VALUE = TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2;
-
-  const mockLzaPrefixParameter = () => {
-    ssmMock.on(GetParameterCommand, {
-      Name: LZA_PREFIX_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: LZA_PREFIX_PARAMETER_NAME,
-        Value: 'AWSAccelerator',
-        Type: 'String',
-      },
-    });
-  };
 
   const mockInstallerVersionParameter = () => {
     ssmMock.on(GetParameterCommand, {
@@ -78,12 +60,15 @@ describe('Init Command', () => {
   const mockFinalizeNotFound = (parameterName: string) => {
     ssmMock.on(GetParameterCommand, {
       Name: parameterName,
-    }).rejects(new Error('ParameterNotFound'));
+    }).rejects(new ParameterNotFound({
+      $metadata: {},
+      message: 'Parameter not found.',
+    }));
   };
 
   const resetSsmInitBase = () => {
     ssmMock.reset();
-    mockLzaPrefixParameter();
+    mockFinalizeVersionParameter(FINALIZE_VERSION_PARAMETER_NAME, FINALIZE_PARAMETER_VALUE);
     mockInstallerVersionParameter();
   };
 
@@ -143,9 +128,7 @@ describe('Init Command', () => {
       ],
     });
 
-    mockLzaPrefixParameter();
-    mockFinalizeVersionParameter(FINALIZE_VERSION_PARAMETER_NAME, FINALIZE_PARAMETER_VALUE);
-    mockInstallerVersionParameter();
+    resetSsmInitBase();
     cloudTrailMock.on(DescribeTrailsCommand).resolves({
       trailList: [
         {
@@ -178,30 +161,32 @@ describe('Init Command', () => {
   });
 
   it('should fail when finalize marker parameter is missing', async () => {
+    resetSsmInitBase();
     mockFinalizeNotFound(FINALIZE_VERSION_PARAMETER_NAME);
     await expect(runInit(TEST_REGION)).rejects.toThrow();
+    expect(ssmMock).toHaveReceivedCommandTimes(GetParameterCommand, 1);
+    expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
+      Name: FINALIZE_VERSION_PARAMETER_NAME,
+    });
 
     expect(fs.existsSync(path.join(temp.directory, 'config.ts'))).toBe(false);
   });
 
-  it('should initialize when finalize marker exists only in global region for a non-global home region', async () => {
+  it('should initialize when global finalize marker exists for a non-global home region', async () => {
     resetSsmInitBase();
-    mockFinalizeNotFound(EU_FINALIZE_PARAMETER_NAME);
-    mockFinalizeVersionParameter(FINALIZE_VERSION_PARAMETER_NAME, FINALIZE_PARAMETER_VALUE);
     await runInit(EU_HOME_REGION);
+    expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
+      Name: FINALIZE_VERSION_PARAMETER_NAME,
+    });
 
     expect(fs.existsSync(path.join(temp.directory, 'config.ts'))).toBe(true);
   });
 
-  it('should fail with both checked finalize parameter paths when marker is missing in home and global region', async () => {
+  it('should fail when global finalize marker is missing for a non-global home region', async () => {
     resetSsmInitBase();
-    mockFinalizeNotFound(EU_FINALIZE_PARAMETER_NAME);
     mockFinalizeNotFound(FINALIZE_VERSION_PARAMETER_NAME);
     await expect(runInit(EU_HOME_REGION)).rejects.toThrow();
-    expect(ssmMock).toHaveReceivedCommandTimes(GetParameterCommand, 3);
-    expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
-      Name: EU_FINALIZE_PARAMETER_NAME,
-    });
+    expect(ssmMock).toHaveReceivedCommandTimes(GetParameterCommand, 1);
     expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
       Name: FINALIZE_VERSION_PARAMETER_NAME,
     });
@@ -211,26 +196,28 @@ describe('Init Command', () => {
     resetSsmInitBase();
     mockFinalizeVersionParameter(FINALIZE_VERSION_PARAMETER_NAME, '');
     await expect(runInit(TEST_REGION)).rejects.toThrow();
-    expect(ssmMock).toHaveReceivedCommandTimes(GetParameterCommand, 2);
+    expect(ssmMock).toHaveReceivedCommandTimes(GetParameterCommand, 1);
     expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
       Name: FINALIZE_VERSION_PARAMETER_NAME,
     });
   });
 
-  it('should initialize when us-gov home region uses us-gov-west-1 finalize marker fallback', async () => {
+  it('should initialize when us-gov home region relies on the global finalize marker', async () => {
     resetSsmInitBase();
-    mockFinalizeNotFound(US_GOV_HOME_FINALIZE_PARAMETER_NAME);
-    mockFinalizeVersionParameter(US_GOV_FINALIZE_PARAMETER_NAME, FINALIZE_PARAMETER_VALUE);
     await runInit(US_GOV_HOME_REGION);
+    expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
+      Name: FINALIZE_VERSION_PARAMETER_NAME,
+    });
 
     expect(fs.existsSync(path.join(temp.directory, 'config.ts'))).toBe(true);
   });
 
-  it('should initialize when cn home region uses cn-northwest-1 finalize marker fallback', async () => {
+  it('should initialize when cn home region relies on the global finalize marker', async () => {
     resetSsmInitBase();
-    mockFinalizeNotFound(CN_HOME_FINALIZE_PARAMETER_NAME);
-    mockFinalizeVersionParameter(CN_FINALIZE_PARAMETER_NAME, FINALIZE_PARAMETER_VALUE);
     await runInit(CN_HOME_REGION);
+    expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
+      Name: FINALIZE_VERSION_PARAMETER_NAME,
+    });
 
     expect(fs.existsSync(path.join(temp.directory, 'config.ts'))).toBe(true);
   });

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -29,8 +29,6 @@ describe('Init Command', () => {
   const cloudTrailMock = mockClient(CloudTrailClient);
   const FINALIZE_VERSION_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${TEST_REGION}/version`;
   const EU_HOME_REGION = 'eu-central-1';
-  const US_GOV_HOME_REGION = 'us-gov-east-1';
-  const CN_HOME_REGION = 'cn-north-1';
   const FINALIZE_PARAMETER_VALUE = TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2;
 
   const mockInstallerVersionParameter = () => {
@@ -201,25 +199,4 @@ describe('Init Command', () => {
       Name: FINALIZE_VERSION_PARAMETER_NAME,
     });
   });
-
-  it('should initialize when us-gov home region relies on the global finalize marker', async () => {
-    resetSsmInitBase();
-    await runInit(US_GOV_HOME_REGION);
-    expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
-      Name: FINALIZE_VERSION_PARAMETER_NAME,
-    });
-
-    expect(fs.existsSync(path.join(temp.directory, 'config.ts'))).toBe(true);
-  });
-
-  it('should initialize when cn home region relies on the global finalize marker', async () => {
-    resetSsmInitBase();
-    await runInit(CN_HOME_REGION);
-    expect(ssmMock).toHaveReceivedCommandWith(GetParameterCommand, {
-      Name: FINALIZE_VERSION_PARAMETER_NAME,
-    });
-
-    expect(fs.existsSync(path.join(temp.directory, 'config.ts'))).toBe(true);
-  });
-
 });

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -9,6 +9,7 @@ import { mockClient } from 'aws-sdk-client-mock';
 import { Init } from '../../src/commands/init';
 import {
   AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
+  GLOBAL_REGION,
 } from '../../src/config';
 import {
   TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2,
@@ -27,7 +28,7 @@ describe('Init Command', () => {
   const ssoMock = mockClient(SSOAdminClient);
   const ssmMock = mockClient(SSMClient);
   const cloudTrailMock = mockClient(CloudTrailClient);
-  const FINALIZE_VERSION_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${TEST_REGION}/version`;
+  const FINALIZE_VERSION_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${GLOBAL_REGION}/version`;
   const EU_HOME_REGION = 'eu-central-1';
   const FINALIZE_PARAMETER_VALUE = TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2;
 

--- a/test/commands/lza-config-validate.test.ts
+++ b/test/commands/lza-config-validate.test.ts
@@ -31,7 +31,6 @@ describe('LZA Config Validate command', () => {
   const organizationsMock = mockClient(OrganizationsClient);
   const ssoAdminMock = mockClient(SSOAdminClient);
   const cloudTrailMock = mockClient(CloudTrailClient);
-  const LZA_PREFIX_PARAMETER_NAME = '/accelerator/lza-prefix';
   const FINALIZE_VERSION_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${TEST_REGION}/version`;
 
   let execSpy: jest.SpyInstance;
@@ -66,15 +65,6 @@ describe('LZA Config Validate command', () => {
       return realExecute(command, opts);
     });
 
-    ssmMock.on(GetParameterCommand, {
-      Name: LZA_PREFIX_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: LZA_PREFIX_PARAMETER_NAME,
-        Value: 'AWSAccelerator',
-        Type: 'String',
-      },
-    });
     ssmMock.on(GetParameterCommand, {
       Name: FINALIZE_VERSION_PARAMETER_NAME,
     }).resolves({

--- a/test/commands/lza-core-bootstrap.test.ts
+++ b/test/commands/lza-core-bootstrap.test.ts
@@ -34,7 +34,6 @@ describe('LZA Core Bootstrap command', () => {
   const organizationsMock = mockClient(OrganizationsClient);
   const ssoAdminMock = mockClient(SSOAdminClient);
   const cloudTrailMock = mockClient(CloudTrailClient);
-  const LZA_PREFIX_PARAMETER_NAME = '/accelerator/lza-prefix';
   const FINALIZE_VERSION_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${TEST_REGION}/version`;
 
   let execSpy: jest.SpyInstance;
@@ -75,15 +74,6 @@ describe('LZA Core Bootstrap command', () => {
       return realExecute(command, opts);
     });
 
-    ssmMock.on(GetParameterCommand, {
-      Name: LZA_PREFIX_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: LZA_PREFIX_PARAMETER_NAME,
-        Value: 'AWSAccelerator',
-        Type: 'String',
-      },
-    });
     ssmMock.on(GetParameterCommand, {
       Name: FINALIZE_VERSION_PARAMETER_NAME,
     }).resolves({

--- a/test/commands/lza-installer-version-check.test.ts
+++ b/test/commands/lza-installer-version-check.test.ts
@@ -31,6 +31,21 @@ describe('LZA Installer Version - check command', () => {
   const ssoAdminMock = mockClient(SSOAdminClient);
   const cloudTrailMock = mockClient(CloudTrailClient);
   const FINALIZE_VERSION_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${TEST_REGION}/version`;
+  const mockVersionParameter = (name: string, value: string): void => {
+    ssmMock.on(GetParameterCommand, { Name: name }).resolves({
+      Parameter: {
+        Name: name,
+        Value: value,
+        Type: 'String',
+      },
+    });
+  };
+  const mockFinalizeVersionForInit = (): void => {
+    mockVersionParameter(FINALIZE_VERSION_PARAMETER_NAME, TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2);
+  };
+  const mockInstalledVersion = (value: string): void => {
+    mockVersionParameter(AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME, value);
+  };
 
   beforeEach(() => {
     temp = useTempDir();
@@ -72,6 +87,7 @@ describe('LZA Installer Version - check command', () => {
         },
       ],
     });
+    mockFinalizeVersionForInit();
   });
 
   afterEach(() => {
@@ -79,25 +95,7 @@ describe('LZA Installer Version - check command', () => {
   });
 
   it('should succeed after init when installed version matches configured version', async () => {
-    // Arrange SSM mock to return the configured version
-    ssmMock.on(GetParameterCommand, {
-      Name: FINALIZE_VERSION_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: FINALIZE_VERSION_PARAMETER_NAME,
-        Value: TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2,
-        Type: 'String',
-      },
-    });
-    ssmMock.on(GetParameterCommand, {
-      Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
-        Value: TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2,
-        Type: 'String',
-      },
-    });
+    mockInstalledVersion(TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2);
 
     const cli = createCliFor(Init, LzaInstallerVersionCheck);
     await runCli(cli, [
@@ -109,15 +107,7 @@ describe('LZA Installer Version - check command', () => {
     ], temp);
     await execModule.executeCommand('npm install', { cwd: temp.directory });
     ssmMock.reset();
-    ssmMock.on(GetParameterCommand, {
-      Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
-        Value: TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2,
-        Type: 'String',
-      },
-    });
+    mockInstalledVersion(TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2);
     await runCli(cli, ['lza', 'installer-version', 'check'], temp);
 
     expect(ssmMock).toHaveReceivedCommandTimes(GetParameterCommand, 1);
@@ -127,25 +117,7 @@ describe('LZA Installer Version - check command', () => {
   });
 
   it('should fail after init when installed version does not match configured version', async () => {
-    ssmMock.on(GetParameterCommand, {
-      Name: FINALIZE_VERSION_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: FINALIZE_VERSION_PARAMETER_NAME,
-        Value: TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2,
-        Type: 'String',
-      },
-    });
-    ssmMock.on(GetParameterCommand, {
-      Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
-        Value: TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2,
-        Type: 'String',
-      },
-    });
-    // Run init to generate config.ts with 1.12.2
+    mockInstalledVersion(TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2);
     const cli = createCliFor(Init, LzaInstallerVersionCheck);
 
     await runCli(cli, [
@@ -157,15 +129,7 @@ describe('LZA Installer Version - check command', () => {
     ], temp);
     await execModule.executeCommand('npm install', { cwd: temp.directory });
     ssmMock.reset();
-    ssmMock.on(GetParameterCommand, {
-      Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
-        Value: TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_3,
-        Type: 'String',
-      },
-    });
+    mockInstalledVersion(TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_3);
     const result = runCli(cli, ['lza', 'installer-version', 'check'], temp);
 
     await expect(result).rejects.toThrow(CliError);

--- a/test/commands/lza-installer-version-check.test.ts
+++ b/test/commands/lza-installer-version-check.test.ts
@@ -30,7 +30,6 @@ describe('LZA Installer Version - check command', () => {
   const organizationsMock = mockClient(OrganizationsClient);
   const ssoAdminMock = mockClient(SSOAdminClient);
   const cloudTrailMock = mockClient(CloudTrailClient);
-  const LZA_PREFIX_PARAMETER_NAME = '/accelerator/lza-prefix';
   const FINALIZE_VERSION_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${TEST_REGION}/version`;
 
   beforeEach(() => {
@@ -82,15 +81,6 @@ describe('LZA Installer Version - check command', () => {
   it('should succeed after init when installed version matches configured version', async () => {
     // Arrange SSM mock to return the configured version
     ssmMock.on(GetParameterCommand, {
-      Name: LZA_PREFIX_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: LZA_PREFIX_PARAMETER_NAME,
-        Value: 'AWSAccelerator',
-        Type: 'String',
-      },
-    });
-    ssmMock.on(GetParameterCommand, {
       Name: FINALIZE_VERSION_PARAMETER_NAME,
     }).resolves({
       Parameter: {
@@ -137,15 +127,6 @@ describe('LZA Installer Version - check command', () => {
   });
 
   it('should fail after init when installed version does not match configured version', async () => {
-    ssmMock.on(GetParameterCommand, {
-      Name: LZA_PREFIX_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: LZA_PREFIX_PARAMETER_NAME,
-        Value: 'AWSAccelerator',
-        Type: 'String',
-      },
-    });
     ssmMock.on(GetParameterCommand, {
       Name: FINALIZE_VERSION_PARAMETER_NAME,
     }).resolves({

--- a/test/commands/lza-installer-version-update.test.ts
+++ b/test/commands/lza-installer-version-update.test.ts
@@ -40,6 +40,21 @@ describe('LZA Installer Version - update command', () => {
   const ssoAdminMock = mockClient(SSOAdminClient);
   const cloudTrailMock = mockClient(CloudTrailClient);
   const FINALIZE_VERSION_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${TEST_REGION}/version`;
+  const mockVersionParameter = (name: string, value: string): void => {
+    ssmMock.on(GetParameterCommand, { Name: name }).resolves({
+      Parameter: {
+        Name: name,
+        Value: value,
+        Type: 'String',
+      },
+    });
+  };
+  const mockFinalizeVersionForInit = (): void => {
+    mockVersionParameter(FINALIZE_VERSION_PARAMETER_NAME, TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2);
+  };
+  const mockInstalledVersion = (value: string): void => {
+    mockVersionParameter(AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME, value);
+  };
 
   beforeEach(() => {
     temp = useTempDir();
@@ -82,6 +97,7 @@ describe('LZA Installer Version - update command', () => {
         },
       ],
     });
+    mockFinalizeVersionForInit();
   });
 
   afterEach(() => {
@@ -90,24 +106,7 @@ describe('LZA Installer Version - update command', () => {
 
   it('should be a no-op when installed version is already up to date', async () => {
     // Installed version equals configured version (1.12.2)
-    ssmMock.on(GetParameterCommand, {
-      Name: FINALIZE_VERSION_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: FINALIZE_VERSION_PARAMETER_NAME,
-        Value: TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2,
-        Type: 'String',
-      },
-    });
-    ssmMock.on(GetParameterCommand, {
-      Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
-        Value: TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2,
-        Type: 'String',
-      },
-    });
+    mockInstalledVersion(TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2);
     const cli = createCliFor(Init, LzaInstallerVersionUpdate);
 
     await runCli(cli, [
@@ -125,15 +124,6 @@ describe('LZA Installer Version - update command', () => {
 
   it('should trigger a CloudFormation update when configured version is newer than installed', async () => {
     // Init sees 1.12.2, then update sees 1.12.1 (older)
-    ssmMock.on(GetParameterCommand, {
-      Name: FINALIZE_VERSION_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: FINALIZE_VERSION_PARAMETER_NAME,
-        Value: TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2,
-        Type: 'String',
-      },
-    });
     ssmMock.on(GetParameterCommand, {
       Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
     })
@@ -199,15 +189,6 @@ describe('LZA Installer Version - update command', () => {
 
   it('should fail when configured version is smaller than installed version', async () => {
     // Init sees 1.12.2, then update sees newer 1.12.3
-    ssmMock.on(GetParameterCommand, {
-      Name: FINALIZE_VERSION_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: FINALIZE_VERSION_PARAMETER_NAME,
-        Value: TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2,
-        Type: 'String',
-      },
-    });
     ssmMock.on(GetParameterCommand, {
       Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
     })

--- a/test/commands/lza-installer-version-update.test.ts
+++ b/test/commands/lza-installer-version-update.test.ts
@@ -39,7 +39,6 @@ describe('LZA Installer Version - update command', () => {
   const organizationsMock = mockClient(OrganizationsClient);
   const ssoAdminMock = mockClient(SSOAdminClient);
   const cloudTrailMock = mockClient(CloudTrailClient);
-  const LZA_PREFIX_PARAMETER_NAME = '/accelerator/lza-prefix';
   const FINALIZE_VERSION_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${TEST_REGION}/version`;
 
   beforeEach(() => {
@@ -92,15 +91,6 @@ describe('LZA Installer Version - update command', () => {
   it('should be a no-op when installed version is already up to date', async () => {
     // Installed version equals configured version (1.12.2)
     ssmMock.on(GetParameterCommand, {
-      Name: LZA_PREFIX_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: LZA_PREFIX_PARAMETER_NAME,
-        Value: 'AWSAccelerator',
-        Type: 'String',
-      },
-    });
-    ssmMock.on(GetParameterCommand, {
       Name: FINALIZE_VERSION_PARAMETER_NAME,
     }).resolves({
       Parameter: {
@@ -135,15 +125,6 @@ describe('LZA Installer Version - update command', () => {
 
   it('should trigger a CloudFormation update when configured version is newer than installed', async () => {
     // Init sees 1.12.2, then update sees 1.12.1 (older)
-    ssmMock.on(GetParameterCommand, {
-      Name: LZA_PREFIX_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: LZA_PREFIX_PARAMETER_NAME,
-        Value: 'AWSAccelerator',
-        Type: 'String',
-      },
-    });
     ssmMock.on(GetParameterCommand, {
       Name: FINALIZE_VERSION_PARAMETER_NAME,
     }).resolves({
@@ -218,15 +199,6 @@ describe('LZA Installer Version - update command', () => {
 
   it('should fail when configured version is smaller than installed version', async () => {
     // Init sees 1.12.2, then update sees newer 1.12.3
-    ssmMock.on(GetParameterCommand, {
-      Name: LZA_PREFIX_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: LZA_PREFIX_PARAMETER_NAME,
-        Value: 'AWSAccelerator',
-        Type: 'String',
-      },
-    });
     ssmMock.on(GetParameterCommand, {
       Name: FINALIZE_VERSION_PARAMETER_NAME,
     }).resolves({

--- a/test/commands/synth.test.ts
+++ b/test/commands/synth.test.ts
@@ -1,3 +1,4 @@
+import { CloudTrailClient, DescribeTrailsCommand } from '@aws-sdk/client-cloudtrail';
 import { DescribeOrganizationCommand, ListRootsCommand, OrganizationsClient } from '@aws-sdk/client-organizations';
 import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
 import { ListInstancesCommand, SSOAdminClient } from '@aws-sdk/client-sso-admin';
@@ -23,6 +24,9 @@ describe('Synth command', () => {
   const stsMock = mockClient(STSClient);
   const organizationsMock = mockClient(OrganizationsClient);
   const ssoAdminMock = mockClient(SSOAdminClient);
+  const cloudTrailMock = mockClient(CloudTrailClient);
+  const LZA_PREFIX_PARAMETER_NAME = '/accelerator/lza-prefix';
+  const FINALIZE_VERSION_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${TEST_REGION}/version`;
 
   beforeEach(() => {
     temp = useTempDir();
@@ -31,9 +35,30 @@ describe('Synth command', () => {
     stsMock.reset();
     organizationsMock.reset();
     ssoAdminMock.reset();
+    cloudTrailMock.reset();
     jest.clearAllMocks();
 
-    ssmMock.on(GetParameterCommand).resolves({
+    ssmMock.on(GetParameterCommand, {
+      Name: LZA_PREFIX_PARAMETER_NAME,
+    }).resolves({
+      Parameter: {
+        Name: LZA_PREFIX_PARAMETER_NAME,
+        Value: 'AWSAccelerator',
+        Type: 'String',
+      },
+    });
+    ssmMock.on(GetParameterCommand, {
+      Name: FINALIZE_VERSION_PARAMETER_NAME,
+    }).resolves({
+      Parameter: {
+        Name: FINALIZE_VERSION_PARAMETER_NAME,
+        Value: TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2,
+        Type: 'String',
+      },
+    });
+    ssmMock.on(GetParameterCommand, {
+      Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
+    }).resolves({
       Parameter: {
         Name: AWS_ACCELERATOR_INSTALLER_STACK_VERSION_SSM_PARAMETER_NAME,
         Value: TEST_AWS_ACCELERATOR_STACK_VERSION_1_12_2,
@@ -70,6 +95,15 @@ describe('Synth command', () => {
         {
           InstanceArn: 'arn:aws:sso:::instance/ssoins-example',
           IdentityStoreId: 'd-example123',
+        },
+      ],
+    });
+
+    cloudTrailMock.on(DescribeTrailsCommand).resolves({
+      trailList: [
+        {
+          IsOrganizationTrail: true,
+          CloudWatchLogsLogGroupArn: `arn:aws:logs:${TEST_REGION}:${TEST_ACCOUNT_ID}:log-group:aws-controltower/CloudTrailLogs-xyz`,
         },
       ],
     });

--- a/test/commands/synth.test.ts
+++ b/test/commands/synth.test.ts
@@ -25,7 +25,6 @@ describe('Synth command', () => {
   const organizationsMock = mockClient(OrganizationsClient);
   const ssoAdminMock = mockClient(SSOAdminClient);
   const cloudTrailMock = mockClient(CloudTrailClient);
-  const LZA_PREFIX_PARAMETER_NAME = '/accelerator/lza-prefix';
   const FINALIZE_VERSION_PARAMETER_NAME = `/accelerator/AWSAccelerator-FinalizeStack-${TEST_ACCOUNT_ID}-${TEST_REGION}/version`;
 
   beforeEach(() => {
@@ -38,15 +37,6 @@ describe('Synth command', () => {
     cloudTrailMock.reset();
     jest.clearAllMocks();
 
-    ssmMock.on(GetParameterCommand, {
-      Name: LZA_PREFIX_PARAMETER_NAME,
-    }).resolves({
-      Parameter: {
-        Name: LZA_PREFIX_PARAMETER_NAME,
-        Value: 'AWSAccelerator',
-        Type: 'String',
-      },
-    });
     ssmMock.on(GetParameterCommand, {
       Name: FINALIZE_VERSION_PARAMETER_NAME,
     }).resolves({

--- a/test/core-cloudtrail-config.test.ts
+++ b/test/core-cloudtrail-config.test.ts
@@ -1,58 +1,32 @@
-import fs from 'node:fs';
-import path from 'node:path';
 import { CloudTrailClient, DescribeTrailsCommand } from '@aws-sdk/client-cloudtrail';
 import { mockClient } from 'aws-sdk-client-mock';
-import { TEST_REGION, TEST_ACCOUNT_ID } from './constants';
-import { baseConfig, Config } from '../src/config';
-import * as configModule from '../src/config';
-import { useTempDir } from './test-helper/use-temp-dir';
-import { applyAutoCloudTrailLogGroupName } from '../src/core/accelerator/config/cloudtrail';
-import * as pathModule from '../src/core/util/path';
+import { TEST_ACCOUNT_ID, TEST_REGION } from './constants';
+import { resolveControlTowerCloudTrailLogGroupName } from '../src/core/accelerator/config/cloudtrail';
 
-const AUTO_PLACEHOLDER = '__AUTO__';
-
-describe('CloudTrail auto log group resolution', () => {
+describe('resolveControlTowerCloudTrailLogGroupName', () => {
   const cloudTrailMock = mockClient(CloudTrailClient);
-  let temp: ReturnType<typeof useTempDir>;
 
   beforeEach(() => {
-    temp = useTempDir();
     cloudTrailMock.reset();
     jest.clearAllMocks();
   });
 
-  afterEach(() => {
-    temp.restore();
-    jest.restoreAllMocks();
+  it('should resolve the organization Control Tower log group name', async () => {
+    cloudTrailMock.on(DescribeTrailsCommand).resolves({
+      trailList: [
+        {
+          IsOrganizationTrail: true,
+          CloudWatchLogsLogGroupArn: logGroupArn('aws-controltower/CloudTrailLogs-org'),
+        },
+      ],
+    });
+
+    await expect(resolveControlTowerCloudTrailLogGroupName(TEST_REGION))
+      .resolves
+      .toBe('aws-controltower/CloudTrailLogs-org');
   });
 
-  it('should skip trail lookup when security config has no placeholder', async () => {
-    arrangeConfig(AUTO_PLACEHOLDER, 'manually-set-log-group');
-
-    await actApply();
-
-    expect(cloudTrailMock).not.toHaveReceivedCommand(DescribeTrailsCommand);
-    expect(readSecurityConfig()).toContain('manually-set-log-group');
-  });
-
-  it('should skip all work when config cloudTrailLogGroupName is not auto', async () => {
-    arrangeConfig('already-configured-value', 'explicit-log-group');
-
-    await actApply();
-
-    expect(cloudTrailMock).not.toHaveReceivedCommand(DescribeTrailsCommand);
-    expect(readSecurityConfig()).toContain('explicit-log-group');
-  });
-
-  it('should preserve original error context when trail lookup fails', async () => {
-    arrangeConfig(AUTO_PLACEHOLDER);
-    cloudTrailMock.on(DescribeTrailsCommand).rejects(new Error('AccessDeniedException'));
-
-    await expect(actApply()).rejects.toThrow('Cause: AccessDeniedException');
-  });
-
-  it('should replace placeholder when exactly one Control Tower log group exists', async () => {
-    arrangeConfig(AUTO_PLACEHOLDER);
+  it('should strip the CloudWatch wildcard suffix from the resolved log group name', async () => {
     cloudTrailMock.on(DescribeTrailsCommand).resolves({
       trailList: [
         {
@@ -62,13 +36,29 @@ describe('CloudTrail auto log group resolution', () => {
       ],
     });
 
-    await actApply();
-
-    expect(readSecurityConfig()).toContain('aws-controltower/CloudTrailLogs-xyz');
+    await expect(resolveControlTowerCloudTrailLogGroupName(TEST_REGION))
+      .resolves
+      .toBe('aws-controltower/CloudTrailLogs-xyz');
   });
 
-  it('should prefer the single organization Control Tower trail when multiple Control Tower trails exist', async () => {
-    arrangeConfig(AUTO_PLACEHOLDER);
+  it('should request trails without shadow trails', async () => {
+    cloudTrailMock.on(DescribeTrailsCommand).resolves({
+      trailList: [
+        {
+          IsOrganizationTrail: true,
+          CloudWatchLogsLogGroupArn: logGroupArn('aws-controltower/CloudTrailLogs-org'),
+        },
+      ],
+    });
+
+    await resolveControlTowerCloudTrailLogGroupName(TEST_REGION);
+
+    expect(cloudTrailMock).toHaveReceivedCommandWith(DescribeTrailsCommand, {
+      includeShadowTrails: false,
+    });
+  });
+
+  it('should throw when no matching organization Control Tower trail exists', async () => {
     cloudTrailMock.on(DescribeTrailsCommand).resolves({
       trailList: [
         {
@@ -77,135 +67,31 @@ describe('CloudTrail auto log group resolution', () => {
         },
         {
           IsOrganizationTrail: true,
-          CloudWatchLogsLogGroupArn: logGroupArn('aws-controltower/CloudTrailLogs-org'),
+          CloudWatchLogsLogGroupArn: logGroupArn('custom/log-group'),
         },
       ],
     });
 
-    await actApply();
-
-    expect(readSecurityConfig()).toContain('aws-controltower/CloudTrailLogs-org');
+    await expect(resolveControlTowerCloudTrailLogGroupName(TEST_REGION))
+      .rejects
+      .toThrow(`Unable to find a Control Tower CloudTrail log group in ${TEST_REGION}.`);
   });
 
-  it('should fail when no Control Tower log group can be resolved', async () => {
-    arrangeConfig(AUTO_PLACEHOLDER);
+  it('should throw when matching trail arn does not contain a log-group marker', async () => {
     cloudTrailMock.on(DescribeTrailsCommand).resolves({
       trailList: [
         {
           IsOrganizationTrail: true,
-          CloudWatchLogsLogGroupArn: logGroupArn('custom/cloudtrail/log-group'),
+          CloudWatchLogsLogGroupArn: `arn:aws:logs:${TEST_REGION}:${TEST_ACCOUNT_ID}:destination:aws-controltower/CloudTrailLogs-org`,
         },
       ],
     });
 
-    await expect(actApply()).rejects.toThrow(
-      `Unable to resolve the Control Tower CloudTrail log group in ${TEST_REGION}.`,
-    );
+    await expect(resolveControlTowerCloudTrailLogGroupName(TEST_REGION))
+      .rejects
+      .toThrow(`Unable to find a Control Tower CloudTrail log group in ${TEST_REGION}.`);
   });
-
-  it('should fail when multiple Control Tower candidates remain ambiguous', async () => {
-    arrangeConfig(AUTO_PLACEHOLDER);
-    cloudTrailMock.on(DescribeTrailsCommand).resolves({
-      trailList: [
-        {
-          IsOrganizationTrail: false,
-          CloudWatchLogsLogGroupArn: logGroupArn('aws-controltower/CloudTrailLogs-a'),
-        },
-        {
-          IsOrganizationTrail: false,
-          CloudWatchLogsLogGroupArn: logGroupArn('aws-controltower/CloudTrailLogs-b'),
-        },
-      ],
-    });
-
-    await expect(actApply()).rejects.toThrow('Found multiple Control Tower CloudTrail log groups');
-  });
-
-
-  it('should strip the CloudWatch logs wildcard suffix from the resolved log group name', async () => {
-    arrangeConfig(AUTO_PLACEHOLDER);
-    cloudTrailMock.on(DescribeTrailsCommand).resolves({
-      trailList: [
-        {
-          IsOrganizationTrail: true,
-          CloudWatchLogsLogGroupArn: `arn:aws:logs:${TEST_REGION}:${TEST_ACCOUNT_ID}:log-group:aws-controltower/CloudTrailLogs-trim:*`,
-        },
-      ],
-    });
-
-    await actApply();
-
-    expect(readSecurityConfig()).toContain('aws-controltower/CloudTrailLogs-trim');
-    expect(readSecurityConfig()).not.toContain(':*');
-  });
-
-  it('should convert non-Error rejections into an error cause message', async () => {
-    arrangeConfig(AUTO_PLACEHOLDER);
-    cloudTrailMock.on(DescribeTrailsCommand).rejects('throttled');
-
-    await expect(actApply()).rejects.toThrow('Cause: throttled');
-  });
-
-  it('should fail when security-config.yaml is missing', async () => {
-    arrangeConfigWithoutSecurityFile(AUTO_PLACEHOLDER);
-
-    await expect(actApply()).rejects.toThrow('Run synth before deploy');
-  });
-
-  const arrangeConfig = (cloudTrailLogGroupName: string, securityLogGroupValue: string = AUTO_PLACEHOLDER): void => {
-    const configOutPath = baseConfig.awsAcceleratorConfigOutPath;
-    const configOutDir = path.join(temp.directory, configOutPath);
-    fs.mkdirSync(configOutDir, { recursive: true });
-
-    fs.writeFileSync(
-      path.join(configOutDir, 'security-config.yaml'),
-      `logging:\n  cloudtrail:\n    cloudWatchLogsLogGroupArn: ${securityLogGroupValue}\n`,
-      'utf8',
-    );
-
-    const config: Config = {
-      ...baseConfig,
-      cloudTrailLogGroupName,
-      awsAcceleratorVersion: '1.14.2',
-      environments: {},
-      templates: [],
-      managementAccountId: TEST_ACCOUNT_ID,
-      homeRegion: TEST_REGION,
-      enabledRegions: [TEST_REGION],
-    };
-
-    jest.spyOn(configModule, 'loadConfigSync').mockReturnValue(config);
-    jest.spyOn(pathModule, 'resolveProjectPath').mockImplementation((input: string) => path.join(temp.directory, input));
-  };
-
-
-  const arrangeConfigWithoutSecurityFile = (cloudTrailLogGroupName: string): void => {
-    const configOutPath = baseConfig.awsAcceleratorConfigOutPath;
-    const configOutDir = path.join(temp.directory, configOutPath);
-    fs.mkdirSync(configOutDir, { recursive: true });
-
-    const config: Config = {
-      ...baseConfig,
-      cloudTrailLogGroupName,
-      awsAcceleratorVersion: '1.14.2',
-      environments: {},
-      templates: [],
-      managementAccountId: TEST_ACCOUNT_ID,
-      homeRegion: TEST_REGION,
-      enabledRegions: [TEST_REGION],
-    };
-
-    jest.spyOn(configModule, 'loadConfigSync').mockReturnValue(config);
-    jest.spyOn(pathModule, 'resolveProjectPath').mockImplementation((input: string) => path.join(temp.directory, input));
-  };
-
-  const actApply = async (): Promise<void> => {
-    await applyAutoCloudTrailLogGroupName();
-  };
-
-  const readSecurityConfig = (): string =>
-    fs.readFileSync(path.join(temp.directory, baseConfig.awsAcceleratorConfigOutPath, 'security-config.yaml'), 'utf8');
-
-  const logGroupArn = (logGroupName: string): string =>
-    `arn:aws:logs:${TEST_REGION}:${TEST_ACCOUNT_ID}:log-group:${logGroupName}:*`;
 });
+
+const logGroupArn = (logGroupName: string): string =>
+  `arn:aws:logs:${TEST_REGION}:${TEST_ACCOUNT_ID}:log-group:${logGroupName}:*`;


### PR DESCRIPTION
**Why**

CloudTrailLogGroupName was resolved during deploy, which broke the expected synth model (rendered config still contained placeholder-like values until deploy-time mutation).

**What**

  - Moved Control Tower CloudTrail log group resolution into init render flow.
  - Removed deploy-time CloudTrail placeholder replacement logic.
  - Added dedicated init precheck module (src/core/blueprint/init-prechecks.ts) and wired it into blueprint rendering.
  - Refactor: Removes complexity

**Behavior changes**

  - init now writes resolved AWS_CLOUDTRAIL_LOG_GROUP_NAME directly into rendered config.
  - synth output is deterministic again (no deferred deploy-time mutation for this value).

**Tests**
  Added/updated test/commands/init.test.ts coverage for:

  - success when finalize marker exists in global region,
  - failure when finalize marker missing in global region,