### PR TITLE
fix: pipeline failure topic reference

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -26,7 +26,7 @@ export const LZA_ACCELERATOR_PACKAGE_PATH = path.join(
   'accelerator',
 );
 export const AWS_ACCELERATOR_PIPELINE_FAILURE_TOPIC_NAME =
-  'aws-accelerator-pipeline-failed-status-topic';
+  'aws-accelerator-pipeline-failure';
 export const AWS_ACCELERATOR_SSM_PARAMETER_INSTALLER_KMS_KEY_ARN =
   '/accelerator/installer/kms/key-arn';
 export const AWS_ACCELERATOR_INSTALLER_STACK_NAME = 'AWSAccelerator-InstallerStack';


### PR DESCRIPTION
With LZA version 1.15.1 the pipeline failure topic name has been changed. See: https://github.com/awslabs/landing-zone-accelerator-on-aws/commit/d44ea9b0e26e67b17e9b8c9b0be7cfba61571f48